### PR TITLE
Update repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["daimond113 <contact@daimond113.com>"]
 description = "A package manager for Roblox"
 homepage = "https://pesde.daimond113.com"
+repository = "https://github.com/daimond113/pesde"
 include = ["src/**/*", "Cargo.toml", "Cargo.lock", "README.md", "LICENSE", "CHANGELOG.md"]
 
 [features]


### PR DESCRIPTION
Update [repository](https://rust-digger.code-maven.com/about-repository) field in `Cargo.toml` to point to the GitHub repo.

This makes the location of the source code show correctly on Crates.io. 🙂